### PR TITLE
feat: add backend server scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+backend/node_modules/
+backend/dist/

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "turbo-arb-bot-backend",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "ethers": "^6.13.0",
+    "express": "^4.19.2",
+    "ws": "^8.17.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.7",
+    "@types/ws": "^8.5.10",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.2"
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,30 @@
+import express from 'express';
+import { createServer } from 'http';
+import { WebSocketServer } from 'ws';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+
+app.get('/api/strategies', (_req, res) => {
+  res.json([
+    {
+      id: 1,
+      name: 'Mock Strategy',
+      description: 'This is a mock strategy'
+    }
+  ]);
+});
+
+const server = createServer(app);
+const wss = new WebSocketServer({ server });
+
+wss.on('connection', (ws) => {
+  ws.send(JSON.stringify({ message: 'WebSocket connection established' }));
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/backend/src/modules/generateStrategyMetadata.ts
+++ b/backend/src/modules/generateStrategyMetadata.ts
@@ -1,0 +1,4 @@
+export function generateStrategyMetadata() {
+  // TODO: Implement strategy metadata generation
+  return {};
+}

--- a/backend/src/modules/scanDiscrepancy.ts
+++ b/backend/src/modules/scanDiscrepancy.ts
@@ -1,0 +1,3 @@
+export async function scanDiscrepancy(): Promise<void> {
+  // TODO: Implement discrepancy scanning
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add Express-based backend with WebSocket support
- stub strategy modules and mock `/api/strategies` route
- scaffold TypeScript build config and npm scripts

## Testing
- `npm --prefix backend install` *(failed: 403 Forbidden)*
- `npm --prefix backend test`
- `npm --prefix backend run build` *(failed: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688d8f6de27c832aa7f4492bc884574a