### PR TITLE
feat: scan price discrepancies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "dev": "ts-node-dev --respawn src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "echo \"No tests\""
+    "test": "npm run build && node --test test/scanDiscrepancy.test.js"
   },
   "dependencies": {
     "dotenv": "^16.4.5",

--- a/backend/src/modules/scanDiscrepancy.ts
+++ b/backend/src/modules/scanDiscrepancy.ts
@@ -1,3 +1,65 @@
-export async function scanDiscrepancy(): Promise<void> {
-  // TODO: Implement discrepancy scanning
+/**
+ * Price information returned from an individual DEX/aggregator
+ */
+export interface DexPrice {
+  source: string;
+  price: number;
 }
+
+/**
+ * Resulting structure describing the detected price gaps for a token.
+ */
+export interface DiscrepancyResult {
+  token: string;
+  prices: DexPrice[];
+  /** Difference between the highest and lowest observed price */
+  gap: number;
+}
+
+// List of DEX/aggregator endpoints to query. These URLs are intentionally
+// simple; consumers of this module can provide a custom `fetch` implementation
+// during testing to avoid real network requests.
+const DEX_ENDPOINTS: Record<string, (token: string) => string> = {
+  uniswap: (token) => `https://api.uniswap.org/v1/quote?token=${token}`,
+  sushiswap: (token) => `https://api.sushi.com/v1/quote?token=${token}`,
+};
+
+/**
+ * Pull prices from configured DEX/aggregators and compute price discrepancies.
+ *
+ * @param tokens - Array of token symbols to check (e.g. ["ETH", "DAI"]).
+ * @param fetcher - Optional fetch implementation for testing/mocking.
+ */
+export async function scanDiscrepancy(
+  tokens: string[],
+  fetcher: typeof fetch = fetch,
+): Promise<DiscrepancyResult[]> {
+  const results: DiscrepancyResult[] = [];
+
+  for (const token of tokens) {
+    const prices: DexPrice[] = [];
+
+    for (const [source, buildUrl] of Object.entries(DEX_ENDPOINTS)) {
+      try {
+        const res = await fetcher(buildUrl(token));
+        const data = await res.json();
+        const price = Number(data.price);
+        if (!Number.isNaN(price)) {
+          prices.push({ source, price });
+        }
+      } catch {
+        // Ignore individual source failures; continue with available data
+      }
+    }
+
+    if (prices.length > 0) {
+      const max = Math.max(...prices.map((p) => p.price));
+      const min = Math.min(...prices.map((p) => p.price));
+      results.push({ token, prices, gap: max - min });
+    }
+  }
+
+  return results;
+}
+
+export default scanDiscrepancy;

--- a/backend/test/scanDiscrepancy.test.js
+++ b/backend/test/scanDiscrepancy.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { scanDiscrepancy } from '../dist/modules/scanDiscrepancy.js';
+
+test('detects price gap between sources', async () => {
+  const mockFetch = async (url) => {
+    if (url.includes('uniswap')) {
+      return { json: async () => ({ price: 100 }) };
+    }
+    if (url.includes('sushi.com')) {
+      return { json: async () => ({ price: 110 }) };
+    }
+    throw new Error('unexpected url');
+  };
+
+  const result = await scanDiscrepancy(['ETH'], mockFetch);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].gap, 10);
+  assert.deepEqual(result[0].prices, [
+    { source: 'uniswap', price: 100 },
+    { source: 'sushiswap', price: 110 },
+  ]);
+});
+
+test('no gap when prices equal', async () => {
+  const mockFetch = async (_url) => ({
+    json: async () => ({ price: 42 }),
+  });
+
+  const result = await scanDiscrepancy(['ETH'], mockFetch);
+  assert.equal(result[0].gap, 0);
+});


### PR DESCRIPTION
## Summary
- add utility to scan DEXs for price discrepancies and report gaps
- wire up test runner
- add unit tests for discrepancy scanning

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688db282be44832a879d79c72681cf0a