### PR TITLE
feat: expand backend modules

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,19 +2,15 @@ import express from 'express';
 import { createServer } from 'http';
 import { WebSocketServer } from 'ws';
 import dotenv from 'dotenv';
+import { generateStrategyMetadata } from './modules/generateStrategyMetadata.js';
+import { scanDiscrepancy } from './modules/scanDiscrepancy.js';
 
 dotenv.config();
 
 const app = express();
 
 app.get('/api/strategies', (_req, res) => {
-  res.json([
-    {
-      id: 1,
-      name: 'Mock Strategy',
-      description: 'This is a mock strategy'
-    }
-  ]);
+  res.json(generateStrategyMetadata());
 });
 
 const server = createServer(app);
@@ -22,6 +18,11 @@ const wss = new WebSocketServer({ server });
 
 wss.on('connection', (ws) => {
   ws.send(JSON.stringify({ message: 'WebSocket connection established' }));
+});
+
+// Kick off a discrepancy scan on startup.
+scanDiscrepancy().catch((err) => {
+  console.error('Failed to scan discrepancy', err);
 });
 
 const PORT = process.env.PORT || 3001;

--- a/backend/src/modules/generateStrategyMetadata.ts
+++ b/backend/src/modules/generateStrategyMetadata.ts
@@ -1,4 +1,16 @@
-export function generateStrategyMetadata() {
-  // TODO: Implement strategy metadata generation
-  return {};
+export interface StrategyMetadata {
+  id: number;
+  name: string;
+  description: string;
+}
+
+export function generateStrategyMetadata(): StrategyMetadata[] {
+  // TODO: Replace with real strategy generation logic
+  return [
+    {
+      id: 1,
+      name: 'Mock Strategy',
+      description: 'This is a mock strategy',
+    },
+  ];
 }

--- a/backend/src/modules/scanDiscrepancy.ts
+++ b/backend/src/modules/scanDiscrepancy.ts
@@ -1,3 +1,4 @@
 export async function scanDiscrepancy(): Promise<void> {
   // TODO: Implement discrepancy scanning
+  return Promise.resolve();
 }


### PR DESCRIPTION
## Summary
- integrate stub modules into backend server and expose mock strategy endpoint
- scaffold strategy metadata generator and discrepancy scanner modules

## Testing
- `npm --prefix backend run build`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_688db8942870832a9a8c04ade73691c4