### PR TITLE
Add execution slice and integrate into store

### DIFF
--- a/frontend/src/features/execution/executionSlice.ts
+++ b/frontend/src/features/execution/executionSlice.ts
@@ -1,0 +1,36 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+interface ExecutionState {
+  pending: boolean
+  txHash: string | null
+  error: string | null
+}
+
+const initialState: ExecutionState = {
+  pending: false,
+  txHash: null,
+  error: null,
+}
+
+const executionSlice = createSlice({
+  name: 'execution',
+  initialState,
+  reducers: {
+    startExecution: (state) => {
+      state.pending = true
+      state.txHash = null
+      state.error = null
+    },
+    executionSuccess: (state, action: PayloadAction<string>) => {
+      state.pending = false
+      state.txHash = action.payload
+    },
+    executionFailure: (state, action: PayloadAction<string>) => {
+      state.pending = false
+      state.error = action.payload
+    },
+  },
+})
+
+export const { startExecution, executionSuccess, executionFailure } = executionSlice.actions
+export default executionSlice.reducer

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -1,11 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit'
 import strategyReducer from './features/strategies/strategySlice'
-//import executionReducer from './features/execution/executionSlice'
+import executionReducer from './features/execution/executionSlice'
 
 export const store = configureStore({
   reducer: {
     strategies: strategyReducer,
-    //execution: executionReducer,
+    execution: executionReducer,
   },
 })
 


### PR DESCRIPTION
## Summary
- add execution Redux slice for tracking transaction state
- wire execution reducer into the store configuration

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d8f47c25c832a8b05702a07a7196d