### PR TITLE
feat: load strategies after wallet connect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,36 @@
 // App.tsx – Main layout + MetaMask wallet connection (wagmi v2)
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
   useAccount,
   useConnect,
   useDisconnect,
 } from 'wagmi'
-//import { injected } from '@wagmi/connectors'
+import { useDispatch, useSelector } from 'react-redux'
+import type { AppDispatch } from './store'
+import { loadStrategies } from './features/strategies/strategySlice'
+import {
+  selectStrategies,
+  selectIsLoading,
+} from './features/strategies/strategySelectors'
 
 const App: React.FC = () => {
   const { address, isConnected } = useAccount()
   const { connect, connectors, isPending, error } = useConnect()
   const { disconnect } = useDisconnect()
 
+  const dispatch = useDispatch<AppDispatch>()
+  const strategies = useSelector(selectStrategies)
+  const strategiesLoading = useSelector(selectIsLoading)
+
   // Pick the injected connector (MetaMask)
   const injectedConnector = connectors.find((c) => c.id === 'injected')
+
+  useEffect(() => {
+    if (isConnected) {
+      dispatch(loadStrategies())
+    }
+  }, [isConnected, dispatch])
 
   return (
     <div className="min-h-screen bg-gray-950 text-white flex flex-col">
@@ -51,7 +67,17 @@ const App: React.FC = () => {
           <div>
             <h2 className="text-lg font-semibold mb-4">Welcome to your dashboard 🚀</h2>
             <div className="rounded border border-gray-700 p-4 bg-gray-800">
-              <p>🔄 Strategy list will be loaded here...</p>
+              {strategiesLoading ? (
+                <p>Loading strategies...</p>
+              ) : (
+                <ul className="list-disc pl-4">
+                  {strategies.map((s) => (
+                    <li key={s.id}>
+                      {s.name} - {s.tokenPair}
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
           </div>
         ) : (

--- a/frontend/src/features/strategies/strategySlice.ts
+++ b/frontend/src/features/strategies/strategySlice.ts
@@ -1,12 +1,7 @@
 // strategySlice.ts – for reference
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-
-export interface Strategy {
-  id: number
-  name: string
-  tokenPair: string
-  profit: number
-}
+import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit'
+import type { Strategy } from '../../services/strategyService'
+import { fetchStrategies } from '../../services/strategyService'
 
 interface StrategyState {
   list: Strategy[]
@@ -20,21 +15,36 @@ const initialState: StrategyState = {
   isLoading: false,
 }
 
+export const loadStrategies = createAsyncThunk('strategies/load', async () => {
+  return await fetchStrategies()
+})
+
 const strategySlice = createSlice({
   name: 'strategies',
   initialState,
   reducers: {
-    setStrategies: (state, action: PayloadAction<Strategy[]>) => {
-      state.list = action.payload
-    },
     setActiveStrategy: (state, action: PayloadAction<number>) => {
       state.activeId = action.payload
     },
-    setLoading: (state, action: PayloadAction<boolean>) => {
-      state.isLoading = action.payload
-    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(loadStrategies.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(
+        loadStrategies.fulfilled,
+        (state, action: PayloadAction<Strategy[]>) => {
+          state.isLoading = false
+          state.list = action.payload
+        },
+      )
+      .addCase(loadStrategies.rejected, (state) => {
+        state.isLoading = false
+      })
   },
 })
 
-export const { setStrategies, setActiveStrategy, setLoading } = strategySlice.actions
+export const { setActiveStrategy } = strategySlice.actions
 export default strategySlice.reducer
+export { type Strategy }

--- a/frontend/src/services/strategyService.ts
+++ b/frontend/src/services/strategyService.ts
@@ -1,0 +1,14 @@
+export interface Strategy {
+  id: number;
+  name: string;
+  tokenPair: string;
+  profit: number;
+}
+
+export async function fetchStrategies(): Promise<Strategy[]> {
+  const response = await fetch('/api/strategies');
+  if (!response.ok) {
+    throw new Error('Failed to fetch strategies');
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add strategy service to fetch `/api/strategies`
- fetch strategies via `createAsyncThunk` with loading state
- trigger strategy loading once wallet connects and show results in dashboard

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d8f658fcc832a9af8ee3134ec9894