### PR TITLE
feat: add strategy metadata generator and tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "dev": "ts-node-dev --respawn src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "echo \"No tests\""
+    "test": "node --loader ts-node/esm test/generateStrategyMetadata.test.ts"
   },
   "dependencies": {
     "dotenv": "^16.4.5",

--- a/backend/src/modules/generateStrategyMetadata.ts
+++ b/backend/src/modules/generateStrategyMetadata.ts
@@ -1,4 +1,55 @@
-export function generateStrategyMetadata() {
-  // TODO: Implement strategy metadata generation
-  return {};
+export type TokenPair = [string, string];
+
+export interface GenerateStrategyParams {
+  /**
+   * Tuple containing base and quote token symbols
+   */
+  tokenPair: TokenPair;
+  /**
+   * Optional array describing the execution path (DEXes, pools, etc.)
+   */
+  path?: string[];
+  /**
+   * Minimum profit in smallest denomination (e.g. wei). Defaults to 0.
+   */
+  minProfit?: number;
+}
+
+export interface StrategyMetadata {
+  tokenPair: TokenPair;
+  path: string[];
+  minProfit: number;
+}
+
+/**
+ * Generates a standardized metadata object for a strategy.
+ * Performs runtime validation and assigns defaults where necessary.
+ */
+export function generateStrategyMetadata({
+  tokenPair,
+  path = [],
+  minProfit = 0,
+}: GenerateStrategyParams): StrategyMetadata {
+  if (!Array.isArray(tokenPair) || tokenPair.length !== 2) {
+    throw new Error('tokenPair must be a tuple of two token symbols');
+  }
+
+  const [base, quote] = tokenPair;
+  if (typeof base !== 'string' || typeof quote !== 'string' || !base || !quote) {
+    throw new Error('tokenPair must contain two non-empty strings');
+  }
+
+  if (!Array.isArray(path) || !path.every((p) => typeof p === 'string')) {
+    throw new Error('path must be an array of strings');
+  }
+
+  if (typeof minProfit !== 'number' || isNaN(minProfit) || minProfit < 0) {
+    throw new Error('minProfit must be a non-negative number');
+  }
+
+  return {
+    tokenPair: [base, quote],
+    path,
+    minProfit,
+  };
 }

--- a/backend/test/generateStrategyMetadata.test.ts
+++ b/backend/test/generateStrategyMetadata.test.ts
@@ -1,0 +1,43 @@
+import { strict as assert } from 'assert';
+
+import {
+  generateStrategyMetadata,
+  StrategyMetadata,
+} from '../src/modules/generateStrategyMetadata.js';
+
+// Typical valid input
+const typical: StrategyMetadata = generateStrategyMetadata({
+  tokenPair: ['ETH', 'DAI'],
+  path: ['uniswap', 'sushiswap'],
+  minProfit: 100,
+});
+
+assert.deepEqual(typical, {
+  tokenPair: ['ETH', 'DAI'],
+  path: ['uniswap', 'sushiswap'],
+  minProfit: 100,
+});
+
+// Default handling for missing optional fields
+const defaults = generateStrategyMetadata({ tokenPair: ['BTC', 'USDT'] });
+assert.deepEqual(defaults, {
+  tokenPair: ['BTC', 'USDT'],
+  path: [],
+  minProfit: 0,
+});
+
+// Invalid token pair should throw
+assert.throws(
+  () => generateStrategyMetadata({ tokenPair: ['ETH'] as any }),
+  /tokenPair/
+);
+
+// Negative minProfit should throw
+assert.throws(
+  () =>
+    generateStrategyMetadata({ tokenPair: ['ETH', 'DAI'], minProfit: -1 }),
+  /minProfit/
+);
+
+console.log('All tests passed');
+


### PR DESCRIPTION
## Summary
- implement `generateStrategyMetadata` to build typed strategy metadata with validation and defaults
- add unit tests for normal and edge cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688db4160eb4832aa3119986698bad75