### PR TITLE
fix: add strategy metadata validation

### DIFF
--- a/backend/src/modules/generateStrategyMetadata.ts
+++ b/backend/src/modules/generateStrategyMetadata.ts
@@ -4,13 +4,33 @@ export interface StrategyMetadata {
   description: string;
 }
 
+function validateStrategyMetadata(data: unknown): StrategyMetadata {
+  if (
+    typeof data !== 'object' ||
+    data === null ||
+    typeof (data as any).id !== 'number' ||
+    typeof (data as any).name !== 'string' ||
+    typeof (data as any).description !== 'string'
+  ) {
+    throw new Error('Invalid strategy metadata');
+  }
+
+  const { id, name, description } = data as {
+    id: number;
+    name: string;
+    description: string;
+  };
+  return { id, name, description };
+}
+
 export function generateStrategyMetadata(): StrategyMetadata[] {
-  // TODO: Replace with real strategy generation logic
-  return [
+  const rawStrategies: unknown[] = [
     {
       id: 1,
       name: 'Mock Strategy',
       description: 'This is a mock strategy',
     },
   ];
+
+  return rawStrategies.map((s) => validateStrategyMetadata(s));
 }


### PR DESCRIPTION
## Summary
- add runtime validation for strategy metadata objects
- apply validation when generating mock strategy list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dc406e354832aa8b07185cf2ddaea