### PR TITLE
chore: scaffold contracts and shared types

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Backend
+# PORT: Port for the Express server
+PORT=3001
+
+# Frontend
+# VITE_RPC_URL: RPC endpoint used by the frontend wagmi client
+VITE_RPC_URL="https://sepolia.example.com"
+
+# Contracts
+# RPC_URL: RPC endpoint for Hardhat network configuration
+RPC_URL="https://sepolia.example.com"
+# PRIVATE_KEY: Deployer private key for contract scripts
+PRIVATE_KEY="0x0000000000000000000000000000000000000000000000000000000000000000"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 backend/node_modules/
 backend/dist/
+frontend/node_modules/
+frontend/dist/
+contracts/node_modules/
+contracts/artifacts/
+contracts/cache/
+.env

--- a/backend/src/modules/generateStrategyMetadata.ts
+++ b/backend/src/modules/generateStrategyMetadata.ts
@@ -1,8 +1,4 @@
-export interface StrategyMetadata {
-  id: number;
-  name: string;
-  description: string;
-}
+import type { StrategyMetadata } from '../../../shared/types';
 
 function validateStrategyMetadata(data: unknown): StrategyMetadata {
   if (

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,11 +4,11 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDirs": ["src", "../shared"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src", "../shared"]
 }

--- a/contracts/contracts/StrategyRegistry.sol
+++ b/contracts/contracts/StrategyRegistry.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.8.20;
+
+contract StrategyRegistry {
+    // Placeholder for strategy registration logic
+}

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,0 +1,21 @@
+import { HardhatUserConfig } from "hardhat/config";
+import "hardhat";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const RPC_URL = process.env.RPC_URL || "";
+const PRIVATE_KEY = process.env.PRIVATE_KEY || "";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.20",
+  networks: {
+    hardhat: {},
+    sepolia: {
+      url: RPC_URL || undefined,
+      accounts: PRIVATE_KEY ? [PRIVATE_KEY] : [],
+    },
+  },
+};
+
+export default config;

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "turbo-arb-bot-contracts",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "hardhat compile",
+    "test": "hardhat test"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "dotenv": "^16.4.5",
+    "hardhat": "^2.22.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.2"
+  }
+}

--- a/contracts/scripts/deploy.ts
+++ b/contracts/scripts/deploy.ts
@@ -1,0 +1,9 @@
+async function main() {
+  // Placeholder deployment script
+  console.log("Deploy script placeholder");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/frontend/src/features/strategies/strategySlice.ts
+++ b/frontend/src/features/strategies/strategySlice.ts
@@ -1,10 +1,10 @@
 // strategySlice.ts – for reference
 import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit'
-import type { Strategy } from '../../services/strategyService'
+import type { StrategyMetadata } from '../../../../shared/types'
 import { fetchStrategies } from '../../services/strategyService'
 
 interface StrategyState {
-  list: Strategy[]
+  list: StrategyMetadata[]
   activeId: number | null
   isLoading: boolean
 }
@@ -34,7 +34,7 @@ const strategySlice = createSlice({
       })
       .addCase(
         loadStrategies.fulfilled,
-        (state, action: PayloadAction<Strategy[]>) => {
+        (state, action: PayloadAction<StrategyMetadata[]>) => {
           state.isLoading = false
           state.list = action.payload
         },
@@ -47,4 +47,4 @@ const strategySlice = createSlice({
 
 export const { setActiveStrategy } = strategySlice.actions
 export default strategySlice.reducer
-export { type Strategy }
+export { type StrategyMetadata }

--- a/frontend/src/services/strategyService.ts
+++ b/frontend/src/services/strategyService.ts
@@ -1,11 +1,6 @@
-export interface Strategy {
-  id: number;
-  name: string;
-  tokenPair: string;
-  profit: number;
-}
+import type { StrategyMetadata } from '../../../shared/types';
 
-export async function fetchStrategies(): Promise<Strategy[]> {
+export async function fetchStrategies(): Promise<StrategyMetadata[]> {
   const response = await fetch('/api/strategies');
   if (!response.ok) {
     throw new Error('Failed to fetch strategies');

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,0 +1,5 @@
+export interface StrategyMetadata {
+  id: number;
+  name: string;
+  description: string;
+}


### PR DESCRIPTION
## Summary
- scaffold Hardhat contracts project with placeholder registry contract and deploy script
- centralize StrategyMetadata interface in shared module and use it in backend and frontend
- document required env vars for backend, frontend, and contracts

## Testing
- `cd contracts && npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/hardhat)*
- `cd contracts && npm test` *(fails: hardhat: not found)*
- `cd backend && npm test`
- `cd backend && npm run build`
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688eae066db4832aa6c1673a51fa9a0a