### PR TITLE
feat: add discrepancy scanning and deployment endpoints

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,27 +1,34 @@
 import express from 'express';
 import { createServer } from 'http';
-import { WebSocketServer } from 'ws';
 import dotenv from 'dotenv';
 import { generateStrategyMetadata } from './modules/generateStrategyMetadata.js';
 import { scanDiscrepancy } from './modules/scanDiscrepancy.js';
+import deployExecutorRoute from './routes/deployExecutor.js';
+import abiRoute from './routes/abi.js';
+import { initWebSocketServer } from '../ws/server.js';
+import { createArbitrageMatrixServer } from '../ws/arbitrageMatrixServer.js';
 
 dotenv.config();
 
 const app = express();
+app.use(express.json());
 
 app.get('/api/strategies', (_req, res) => {
   res.json(generateStrategyMetadata());
 });
 
-const server = createServer(app);
-const wss = new WebSocketServer({ server });
+app.use('/api/deploy-executor', deployExecutorRoute);
+app.use('/api/abi', abiRoute);
 
-wss.on('connection', (ws) => {
-  ws.send(JSON.stringify({ message: 'WebSocket connection established' }));
-});
+const server = createServer(app);
+const wss = initWebSocketServer(server);
+const matrixServer = createArbitrageMatrixServer(wss);
 
 // Kick off a discrepancy scan on startup.
-scanDiscrepancy().catch((err) => {
+scanDiscrepancy(
+  (d) => matrixServer.broadcastDiscrepancy(d),
+  (heatmap) => matrixServer.broadcastHeatmap(heatmap),
+).catch((err) => {
   console.error('Failed to scan discrepancy', err);
 });
 

--- a/backend/src/modules/mintStrategyOnChain.ts
+++ b/backend/src/modules/mintStrategyOnChain.ts
@@ -1,0 +1,20 @@
+import { Contract, Signer } from 'ethers';
+
+// Minimal ABI with a single mint function. Real-world usage would supply the
+// full contract ABI.
+const MINT_ABI = ['function mint() returns (uint256)'];
+
+/**
+ * Trigger a mint function on a contract using the provided signer.  The
+ * function returns the transaction hash once the transaction has been
+ * broadcast.
+ */
+export async function mintStrategyOnChain(
+  signer: Signer,
+  contractAddress: string,
+): Promise<string> {
+  const contract = new Contract(contractAddress, MINT_ABI, signer);
+  const tx = await contract.mint();
+  const receipt = await tx.wait();
+  return receipt.hash;
+}

--- a/backend/src/modules/scanDiscrepancy.ts
+++ b/backend/src/modules/scanDiscrepancy.ts
@@ -1,4 +1,69 @@
-export async function scanDiscrepancy(): Promise<void> {
-  // TODO: Implement discrepancy scanning
-  return Promise.resolve();
+import { JsonRpcProvider } from 'ethers';
+import { scanUniswapReserves } from './scanUniswapReserves.js';
+
+export interface DiscrepancyResult {
+  pair: string;
+  dexA: string;
+  dexB: string;
+  priceA: number;
+  priceB: number;
+  percentage: number;
 }
+
+/**
+ * Scan for price discrepancies between two liquidity pools.  The function is a
+ * lightweight example and is not meant to be used in production trading
+ * systems.  When a discrepancy is found the optional callbacks are used to
+ * broadcast the individual result and the aggregated heatmap respectively.
+ */
+export async function scanDiscrepancy(
+  onDiscrepancy?: (data: DiscrepancyResult) => void,
+  onHeatmap?: (data: DiscrepancyResult[]) => void,
+): Promise<DiscrepancyResult[]> {
+  const provider = new JsonRpcProvider(
+    process.env.RPC_URL ?? 'https://rpc.ankr.com/eth',
+  );
+
+  // Example pools – WETH/USDC on Uniswap and SushiSwap.  Addresses are public
+  // mainnet deployments and serve as sensible defaults for local development.
+  const pairs = [
+    {
+      symbol: 'WETH/USDC',
+      dexA: { name: 'Uniswap', address: process.env.UNI_WETH_USDC ?? '0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc' },
+      dexB: { name: 'SushiSwap', address: process.env.SUSHI_WETH_USDC ?? '0x397FF1542f962076d0BFE58eA045FfA2d347ACa0' },
+    },
+  ];
+
+  const results: DiscrepancyResult[] = [];
+
+  for (const p of pairs) {
+    const reservesA = await scanUniswapReserves(provider, p.dexA.address);
+    const reservesB = await scanUniswapReserves(provider, p.dexB.address);
+
+    const priceA = Number(reservesA.reserve1) / Number(reservesA.reserve0);
+    const priceB = Number(reservesB.reserve1) / Number(reservesB.reserve0);
+    const percentage = Math.abs(priceA - priceB) / priceA;
+
+    const result: DiscrepancyResult = {
+      pair: p.symbol,
+      dexA: p.dexA.name,
+      dexB: p.dexB.name,
+      priceA,
+      priceB,
+      percentage,
+    };
+
+    results.push(result);
+
+    if (onDiscrepancy) {
+      onDiscrepancy(result);
+    }
+  }
+
+  if (onHeatmap) {
+    onHeatmap(results);
+  }
+
+  return results;
+}
+

--- a/backend/src/modules/scanUniswapReserves.ts
+++ b/backend/src/modules/scanUniswapReserves.ts
@@ -1,0 +1,26 @@
+import { Contract, Provider } from 'ethers';
+
+const RESERVES_ABI = [
+  'function getReserves() view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)',
+];
+
+export interface Reserves {
+  reserve0: bigint;
+  reserve1: bigint;
+}
+
+/**
+ * Fetch the reserves for a Uniswap V2 style pair contract.
+ *
+ * @param provider An ethers.js provider connected to an Ethereum JSON RPC
+ * endpoint.
+ * @param pairAddress Address of the pair contract.
+ */
+export async function scanUniswapReserves(
+  provider: Provider,
+  pairAddress: string,
+): Promise<Reserves> {
+  const contract = new Contract(pairAddress, RESERVES_ABI, provider);
+  const [reserve0, reserve1] = await contract.getReserves();
+  return { reserve0, reserve1 };
+}

--- a/backend/src/routes/abi.ts
+++ b/backend/src/routes/abi.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { fetchAbiFromEtherscan } from '../utils/fetchAbiFromEtherscan.js';
+
+const router = Router();
+
+router.get('/:address', async (req, res) => {
+  try {
+    const { address } = req.params;
+    const abi = await fetchAbiFromEtherscan(address);
+    res.json(abi);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message ?? 'failed to fetch abi' });
+  }
+});
+
+export default router;

--- a/backend/src/routes/deployExecutor.ts
+++ b/backend/src/routes/deployExecutor.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import { JsonRpcProvider, Wallet } from 'ethers';
+import { mintStrategyOnChain } from '../modules/mintStrategyOnChain.js';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const { contractAddress } = req.body as { contractAddress?: string };
+    if (!contractAddress) {
+      res.status(400).json({ error: 'contractAddress is required' });
+      return;
+    }
+
+    const rpcUrl = process.env.RPC_URL;
+    const privateKey = process.env.PRIVATE_KEY;
+    if (!rpcUrl || !privateKey) {
+      throw new Error('RPC_URL and PRIVATE_KEY env variables must be set');
+    }
+
+    const provider = new JsonRpcProvider(rpcUrl);
+    const signer = new Wallet(privateKey, provider);
+    const txHash = await mintStrategyOnChain(signer, contractAddress);
+
+    res.json({ txHash });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message ?? 'unknown error' });
+  }
+});
+
+export default router;

--- a/backend/src/utils/fetchAbiFromEtherscan.ts
+++ b/backend/src/utils/fetchAbiFromEtherscan.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+// Simple on-disk cache directory.
+const CACHE_DIR = path.resolve(process.cwd(), 'backend', '.abi-cache');
+
+/**
+ * Fetches the ABI for a contract from Etherscan.  Results are cached on disk to
+ * avoid repeated network calls.
+ */
+export async function fetchAbiFromEtherscan(address: string): Promise<unknown> {
+  if (!address) {
+    throw new Error('address is required');
+  }
+
+  if (!fs.existsSync(CACHE_DIR)) {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+  }
+
+  const cacheFile = path.join(CACHE_DIR, `${address.toLowerCase()}.json`);
+  if (fs.existsSync(cacheFile)) {
+    const cached = fs.readFileSync(cacheFile, 'utf8');
+    return JSON.parse(cached);
+  }
+
+  const apiKey = process.env.ETHERSCAN_API_KEY ?? '';
+  const url = `https://api.etherscan.io/api?module=contract&action=getabi&address=${address}&apikey=${apiKey}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Etherscan request failed with status ${response.status}`);
+  }
+
+  const data = (await response.json()) as {
+    status: string;
+    message: string;
+    result: string;
+  };
+
+  if (data.status !== '1') {
+    throw new Error(`Etherscan error: ${data.message}`);
+  }
+
+  const abi = JSON.parse(data.result);
+  fs.writeFileSync(cacheFile, JSON.stringify(abi));
+  return abi;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,11 +4,11 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "outDir": "dist",
-    "rootDirs": ["src", "../shared"],
+    "rootDirs": ["src", "ws", "../shared"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src", "../shared"]
+  "include": ["src", "ws", "../shared"]
 }

--- a/backend/ws/arbitrageMatrixServer.ts
+++ b/backend/ws/arbitrageMatrixServer.ts
@@ -1,0 +1,18 @@
+import type { WebSocketServer } from 'ws';
+import { broadcast } from './server.js';
+
+/**
+ * Helper around a WebSocket server that knows how to broadcast arbitrage
+ * specific messages.  Clients can listen for `discrepancy` and `heatmap` events
+ * to receive updates.
+ */
+export function createArbitrageMatrixServer(wss: WebSocketServer) {
+  return {
+    broadcastDiscrepancy(data: unknown) {
+      broadcast(wss, { type: 'discrepancy', data });
+    },
+    broadcastHeatmap(data: unknown) {
+      broadcast(wss, { type: 'heatmap', data });
+    },
+  };
+}

--- a/backend/ws/server.ts
+++ b/backend/ws/server.ts
@@ -1,0 +1,24 @@
+import { Server as HttpServer } from 'http';
+import { WebSocketServer, WebSocket } from 'ws';
+
+/**
+ * Initialise a WebSocket server and return it.  Each new connection will be
+ * greeted with a simple message so clients know the connection is ready.
+ */
+export function initWebSocketServer(server: HttpServer): WebSocketServer {
+  const wss = new WebSocketServer({ server });
+  wss.on('connection', (ws: WebSocket) => {
+    ws.send(JSON.stringify({ message: 'WebSocket connection established' }));
+  });
+  return wss;
+}
+
+/** Broadcast a JSON serialisable payload to all connected clients. */
+export function broadcast(wss: WebSocketServer, data: unknown): void {
+  const message = typeof data === 'string' ? data : JSON.stringify(data);
+  wss.clients.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(message);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- scan liquidity pools for price gaps and broadcast results
- add Uniswap reserve and on-chain mint helpers
- expose deploy-executor and ABI fetch endpoints
- add websocket servers for discrepancy and heatmap data

## Testing
- `cd backend && npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eba96b34c832a88b3255cd04b4ba8