### PR TITLE
Add token pair to strategy metadata

### DIFF
--- a/backend/src/modules/generateStrategyMetadata.ts
+++ b/backend/src/modules/generateStrategyMetadata.ts
@@ -6,17 +6,20 @@ function validateStrategyMetadata(data: unknown): StrategyMetadata {
     data === null ||
     typeof (data as any).id !== 'number' ||
     typeof (data as any).name !== 'string' ||
-    typeof (data as any).description !== 'string'
+    typeof (data as any).description !== 'string' ||
+    typeof (data as any).tokenPair !== 'string' ||
+    (data as any).tokenPair.trim() === ''
   ) {
     throw new Error('Invalid strategy metadata');
   }
 
-  const { id, name, description } = data as {
+  const { id, name, description, tokenPair } = data as {
     id: number;
     name: string;
     description: string;
+    tokenPair: string;
   };
-  return { id, name, description };
+  return { id, name, description, tokenPair };
 }
 
 export function generateStrategyMetadata(): StrategyMetadata[] {
@@ -25,6 +28,7 @@ export function generateStrategyMetadata(): StrategyMetadata[] {
       id: 1,
       name: 'Mock Strategy',
       description: 'This is a mock strategy',
+      tokenPair: 'ETH/DAI',
     },
   ];
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,7 +73,8 @@ const App: React.FC = () => {
                 <ul className="list-disc pl-4">
                   {strategies.map((s) => (
                     <li key={s.id}>
-                      {s.name} - {s.tokenPair}
+                      {s.name}
+                      {s.tokenPair ? ` - ${s.tokenPair}` : ''}
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/features/strategies/strategySlice.ts
+++ b/frontend/src/features/strategies/strategySlice.ts
@@ -36,7 +36,10 @@ const strategySlice = createSlice({
         loadStrategies.fulfilled,
         (state, action: PayloadAction<StrategyMetadata[]>) => {
           state.isLoading = false
-          state.list = action.payload
+          state.list = action.payload.map((s) => ({
+            ...s,
+            tokenPair: s.tokenPair ?? '',
+          }))
         },
       )
       .addCase(loadStrategies.rejected, (state) => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2,4 +2,5 @@ export interface StrategyMetadata {
   id: number;
   name: string;
   description: string;
+  tokenPair: string;
 }


### PR DESCRIPTION
## Summary
- track tokenPair in shared strategy metadata
- validate and supply tokenPair from backend generator
- expose tokenPair through strategy slice and display safely in UI

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68994242b830832aba53e1e8e4cce193