### PR TITLE
fix: use consistent ABI cache path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 backend/node_modules/
 backend/dist/
+backend/abi-cache/
 frontend/node_modules/
 frontend/dist/
 contracts/node_modules/

--- a/backend/src/utils/fetchAbiFromEtherscan.ts
+++ b/backend/src/utils/fetchAbiFromEtherscan.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 // Simple on-disk cache directory.
-const CACHE_DIR = path.resolve(process.cwd(), 'backend', '.abi-cache');
+const CACHE_DIR = path.resolve(process.cwd(), 'backend', 'abi-cache');
 
 /**
  * Fetches the ABI for a contract from Etherscan.  Results are cached on disk to


### PR DESCRIPTION
## Summary
- ensure backend ABI cache uses `backend/abi-cache` directory consistently
- ignore ABI cache directory in version control

## Testing
- `cd backend && npm test`
- `cd backend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689948959180832ab9766a2478d25c9f