### PR TITLE
refactor(frontend): use typed redux hooks

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,8 +6,7 @@ import {
   useConnect,
   useDisconnect,
 } from 'wagmi'
-import { useDispatch, useSelector } from 'react-redux'
-import type { AppDispatch } from './store'
+import { useAppDispatch, useAppSelector } from './hooks'
 import { loadStrategies } from './features/strategies/strategySlice'
 import {
   selectStrategies,
@@ -19,9 +18,9 @@ const App: React.FC = () => {
   const { connect, connectors, isPending, error } = useConnect()
   const { disconnect } = useDisconnect()
 
-  const dispatch = useDispatch<AppDispatch>()
-  const strategies = useSelector(selectStrategies)
-  const strategiesLoading = useSelector(selectIsLoading)
+  const dispatch = useAppDispatch()
+  const strategies = useAppSelector(selectStrategies)
+  const strategiesLoading = useAppSelector(selectIsLoading)
 
   // Pick the injected connector (MetaMask)
   const injectedConnector = connectors.find((c) => c.id === 'injected')

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useAppDispatch } from './useAppDispatch'
+export { useAppSelector } from './useAppSelector'


### PR DESCRIPTION
## Summary
- replace raw `useDispatch` and `useSelector` with typed `useAppDispatch` and `useAppSelector`
- expose typed redux hooks via barrel file for cleaner imports

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689949d6f044832abe134a5f5aa6edbe